### PR TITLE
test: use cargo-hack to avoid cargo test - killed by GitHub runner

### DIFF
--- a/crate/cli/src/tests/kms/certificates/certify.rs
+++ b/crate/cli/src/tests/kms/certificates/certify.rs
@@ -21,6 +21,8 @@ use uuid::Uuid;
 use x509_parser::{der_parser::oid, prelude::*};
 
 use super::validate;
+#[cfg(not(feature = "fips"))]
+use crate::tests::kms::rsa::create_key_pair::{RsaKeyPairOptions, create_rsa_key_pair};
 use crate::{
     actions::kms::certificates::Algorithm,
     config::COSMIAN_CLI_CONF_ENV,
@@ -33,7 +35,6 @@ use crate::{
                 export::export_certificate,
                 import::{ImportCertificateInput, import_certificate},
             },
-            rsa::create_key_pair::{RsaKeyPairOptions, create_rsa_key_pair},
             shared::{ExportKeyParams, export_key},
             utils::{extract_uids::extract_unique_identifier, recover_cmd_logs},
         },
@@ -465,6 +466,7 @@ async fn test_certify_a_csr_with_extensions() -> CosmianResult<()> {
     Ok(())
 }
 
+#[cfg(not(feature = "fips"))]
 #[tokio::test]
 async fn test_certify_a_public_key_test_without_extensions() -> CosmianResult<()> {
     log_init(None);
@@ -507,6 +509,7 @@ async fn test_certify_a_public_key_test_without_extensions() -> CosmianResult<()
     Ok(())
 }
 
+#[cfg(not(feature = "fips"))]
 #[tokio::test]
 async fn test_certify_a_public_key_test_with_extensions() -> CosmianResult<()> {
     log_init(None);
@@ -652,6 +655,7 @@ async fn test_certify_issue_with_subject_name() -> CosmianResult<()> {
     Ok(())
 }
 
+#[cfg(not(feature = "fips"))]
 #[tokio::test]
 async fn test_certify_a_public_key_test_self_signed() -> CosmianResult<()> {
     log_init(None);
@@ -689,6 +693,7 @@ async fn test_certify_a_public_key_test_self_signed() -> CosmianResult<()> {
     Ok(())
 }
 
+#[cfg(not(feature = "fips"))]
 pub(crate) fn create_self_signed_cert(ctx: &TestsContext) -> CosmianResult<String> {
     // create an RSA key pair
     let (_private_key_id, public_key_id) =
@@ -709,6 +714,7 @@ pub(crate) fn create_self_signed_cert(ctx: &TestsContext) -> CosmianResult<Strin
     Ok(certificate_id)
 }
 
+#[cfg(not(feature = "fips"))]
 #[tokio::test]
 async fn test_certify_issue_with_subject_name_self_signed_without_extensions() -> CosmianResult<()>
 {

--- a/crate/cli/src/tests/kms/certificates/export.rs
+++ b/crate/cli/src/tests/kms/certificates/export.rs
@@ -25,6 +25,8 @@ use tempfile::TempDir;
 use test_kms_server::start_default_test_kms_server;
 use uuid::Uuid;
 
+#[cfg(not(feature = "fips"))]
+use crate::tests::kms::certificates::certify::create_self_signed_cert;
 use crate::{
     actions::kms::certificates::Algorithm,
     config::COSMIAN_CLI_CONF_ENV,
@@ -34,9 +36,7 @@ use crate::{
         kms::{
             KMS_SUBCOMMAND,
             certificates::{
-                certify::{
-                    CertifyOp, certify, create_self_signed_cert, import_root_and_intermediate,
-                },
+                certify::{CertifyOp, certify, import_root_and_intermediate},
                 import::{ImportCertificateInput, import_certificate},
             },
             shared::{ExportKeyParams, export_key},
@@ -425,6 +425,7 @@ pub(crate) fn export_certificate(
     ))
 }
 
+#[cfg(not(feature = "fips"))]
 #[tokio::test]
 async fn test_self_signed_export_loop() -> CosmianResult<()> {
     // Create a test server

--- a/crate/cli/src/tests/kms/elliptic_curve/mod.rs
+++ b/crate/cli/src/tests/kms/elliptic_curve/mod.rs
@@ -1,5 +1,7 @@
+#[cfg(not(feature = "fips"))]
 pub(crate) mod create_key_pair;
 #[cfg(not(feature = "fips"))]
 pub(crate) mod encrypt_decrypt;
 
+#[cfg(not(feature = "fips"))]
 pub(crate) const SUB_COMMAND: &str = "ec";

--- a/crate/cli/src/tests/kms/hsm/encrypt_decrypt.rs
+++ b/crate/cli/src/tests/kms/hsm/encrypt_decrypt.rs
@@ -1,28 +1,32 @@
+#[cfg(not(feature = "fips"))]
 use std::{fs, path::PathBuf};
 
+use cosmian_kms_client::reexport::cosmian_kms_client_utils::{
+    create_utils::SymmetricAlgorithm, symmetric_utils::DataEncryptionAlgorithm,
+};
+#[cfg(not(feature = "fips"))]
 use cosmian_kms_client::{
     read_bytes_from_file,
-    reexport::cosmian_kms_client_utils::{
-        create_utils::SymmetricAlgorithm,
-        rsa_utils::{HashFn, RsaEncryptionAlgorithm},
-        symmetric_utils::DataEncryptionAlgorithm,
-    },
+    reexport::cosmian_kms_client_utils::rsa_utils::{HashFn, RsaEncryptionAlgorithm},
 };
 use cosmian_logger::log_init;
+#[cfg(not(feature = "fips"))]
 use tempfile::TempDir;
 use test_kms_server::start_default_test_kms_server_with_utimaco_hsm;
+#[cfg(not(feature = "fips"))]
 use tracing::trace;
 use uuid::Uuid;
 
+#[cfg(not(feature = "fips"))]
+use crate::tests::kms::rsa::{
+    create_key_pair::{RsaKeyPairOptions, create_rsa_key_pair},
+    encrypt_decrypt::{decrypt, encrypt},
+};
 use crate::{
     actions::kms::symmetric::{KeyEncryptionAlgorithm, keys::create_key::CreateKeyAction},
     error::result::CosmianResult,
-    tests::kms::{
-        rsa::{
-            create_key_pair::{RsaKeyPairOptions, create_rsa_key_pair},
-            encrypt_decrypt::{decrypt, encrypt},
-        },
-        symmetric::{create_key::create_symmetric_key, encrypt_decrypt::run_encrypt_decrypt_test},
+    tests::kms::symmetric::{
+        create_key::create_symmetric_key, encrypt_decrypt::run_encrypt_decrypt_test,
     },
 };
 
@@ -51,6 +55,7 @@ pub(crate) async fn test_aes_gcm() -> CosmianResult<()> {
     )
 }
 
+#[cfg(not(feature = "fips"))]
 #[tokio::test]
 pub(crate) async fn test_rsa_pkcs_oaep() -> CosmianResult<()> {
     log_init(None);

--- a/crate/cli/src/tests/kms/hsm/mod.rs
+++ b/crate/cli/src/tests/kms/hsm/mod.rs
@@ -7,16 +7,16 @@
 //! ```
 
 #[cfg(not(feature = "fips"))]
-use crate::tests::kms::hsm::encrypt_decrypt::test_rsa_pkcs_v15;
 use crate::{
     error::result::CosmianResult,
-    tests::kms::hsm::encrypt_decrypt::{test_aes_gcm, test_rsa_pkcs_oaep},
+    tests::kms::hsm::encrypt_decrypt::{test_aes_gcm, test_rsa_pkcs_oaep, test_rsa_pkcs_v15},
 };
 
 mod encrypt_decrypt;
 mod revoke_destroy;
 mod wrap_with_hsm_key;
 
+#[cfg(not(feature = "fips"))]
 #[test]
 fn test_all_hsm_cli() -> CosmianResult<()> {
     test_aes_gcm()?;

--- a/crate/cli/src/tests/kms/hsm/wrap_with_hsm_key.rs
+++ b/crate/cli/src/tests/kms/hsm/wrap_with_hsm_key.rs
@@ -1,20 +1,26 @@
+#[cfg(not(feature = "fips"))]
+use cosmian_kms_client::reexport::cosmian_kms_client_utils::export_utils::ExportKeyFormat;
 use cosmian_kms_client::reexport::cosmian_kms_client_utils::{
-    create_utils::SymmetricAlgorithm, export_utils::ExportKeyFormat,
-    symmetric_utils::DataEncryptionAlgorithm,
+    create_utils::SymmetricAlgorithm, symmetric_utils::DataEncryptionAlgorithm,
 };
 use cosmian_logger::log_init;
+#[cfg(not(feature = "fips"))]
 use tempfile::TempDir;
 use test_kms_server::start_default_test_kms_server_with_utimaco_hsm;
+#[cfg(not(feature = "fips"))]
 use tracing::info;
 use uuid::Uuid;
 
+#[cfg(not(feature = "fips"))]
+use crate::tests::kms::{
+    rsa::create_key_pair::{RsaKeyPairOptions, create_rsa_key_pair},
+    shared::{ExportKeyParams, export_key},
+};
 use crate::{
     actions::kms::symmetric::{KeyEncryptionAlgorithm, keys::create_key::CreateKeyAction},
     error::result::CosmianResult,
-    tests::kms::{
-        rsa::create_key_pair::{RsaKeyPairOptions, create_rsa_key_pair},
-        shared::{ExportKeyParams, export_key},
-        symmetric::{create_key::create_symmetric_key, encrypt_decrypt::run_encrypt_decrypt_test},
+    tests::kms::symmetric::{
+        create_key::create_symmetric_key, encrypt_decrypt::run_encrypt_decrypt_test,
     },
 };
 
@@ -66,6 +72,7 @@ pub(crate) async fn test_wrap_with_aes_gcm() -> CosmianResult<()> {
     )
 }
 
+#[cfg(not(feature = "fips"))]
 #[tokio::test]
 pub(crate) async fn test_wrap_with_rsa_oaep() -> CosmianResult<()> {
     log_init(None);
@@ -113,6 +120,7 @@ pub(crate) async fn test_wrap_with_rsa_oaep() -> CosmianResult<()> {
     )
 }
 
+#[cfg(not(feature = "fips"))]
 #[tokio::test]
 pub(crate) async fn test_unwrap_on_export() -> CosmianResult<()> {
     log_init(option_env!("RUST_LOG"));

--- a/crate/cli/src/tests/kms/rsa/encrypt_decrypt.rs
+++ b/crate/cli/src/tests/kms/rsa/encrypt_decrypt.rs
@@ -105,7 +105,6 @@ pub(crate) fn decrypt(
     ))
 }
 
-#[cfg(not(feature = "fips"))]
 #[tokio::test]
 async fn test_rsa_encrypt_decrypt_using_ckm_rsa_pkcs() -> CosmianResult<()> {
     // to enable this, add cosmian_logger = { workspace = true } to dev-dependencies in Cargo.toml

--- a/crate/cli/src/tests/kms/rsa/mod.rs
+++ b/crate/cli/src/tests/kms/rsa/mod.rs
@@ -1,4 +1,7 @@
+#[cfg(not(feature = "fips"))]
 pub(crate) mod create_key_pair;
+#[cfg(not(feature = "fips"))]
 pub(crate) mod encrypt_decrypt;
 
+#[cfg(not(feature = "fips"))]
 pub(crate) const SUB_COMMAND: &str = "rsa";

--- a/crate/cli/src/tests/kms/shared/destroy.rs
+++ b/crate/cli/src/tests/kms/shared/destroy.rs
@@ -7,12 +7,15 @@ use cosmian_kms_client::{
 };
 use tempfile::TempDir;
 use test_kms_server::start_default_test_kms_server;
+#[cfg(not(feature = "fips"))]
 use tracing::trace;
 
 #[cfg(not(feature = "fips"))]
 use crate::tests::kms::cover_crypt::{
     master_key_pair::create_cc_master_key_pair, user_decryption_keys::create_user_decryption_key,
 };
+#[cfg(not(feature = "fips"))]
+use crate::tests::kms::elliptic_curve::create_key_pair::create_ec_key_pair;
 use crate::{
     actions::kms::symmetric::keys::create_key::CreateKeyAction,
     cli_bail,
@@ -22,7 +25,6 @@ use crate::{
         PROG_NAME,
         kms::{
             KMS_SUBCOMMAND,
-            elliptic_curve::create_key_pair::create_ec_key_pair,
             shared::{ExportKeyParams, export::export_key, revoke::revoke},
             symmetric::create_key::create_symmetric_key,
             utils::recover_cmd_logs,
@@ -149,6 +151,7 @@ async fn test_destroy_and_remove_symmetric_key() -> CosmianResult<()> {
     assert_destroyed(&ctx.owner_client_conf_path, &key_id, true)
 }
 
+#[cfg(not(feature = "fips"))]
 #[tokio::test]
 async fn test_destroy_ec_key() -> CosmianResult<()> {
     // init the test server
@@ -210,6 +213,7 @@ async fn test_destroy_ec_key() -> CosmianResult<()> {
     Ok(())
 }
 
+#[cfg(not(feature = "fips"))]
 #[tokio::test]
 async fn test_destroy_and_remove_ec_key() -> CosmianResult<()> {
     // init the test server

--- a/crate/cli/src/tests/kms/shared/export.rs
+++ b/crate/cli/src/tests/kms/shared/export.rs
@@ -3,20 +3,21 @@ use std::path::Path;
 use std::process::Command;
 
 use assert_cmd::prelude::*;
-use cosmian_kms_client::{
-    kmip_0::kmip_types::BlockCipherMode,
-    kmip_2_1::kmip_types::KeyFormatType,
-    read_bytes_from_file, read_object_from_json_ttlv_file,
-    reexport::cosmian_kms_client_utils::export_utils::{ExportKeyFormat, WrappingAlgorithm},
-};
 #[cfg(not(feature = "fips"))]
 use cosmian_kms_client::{
+    kmip_0::kmip_types::BlockCipherMode,
     kmip_2_1::{
         kmip_data_structures::KeyMaterial,
         kmip_types::{CryptographicAlgorithm, RecommendedCurve},
     },
     pad_be_bytes,
 };
+use cosmian_kms_client::{
+    kmip_2_1::kmip_types::KeyFormatType,
+    read_bytes_from_file, read_object_from_json_ttlv_file,
+    reexport::cosmian_kms_client_utils::export_utils::{ExportKeyFormat, WrappingAlgorithm},
+};
+#[cfg(not(feature = "fips"))]
 use cosmian_logger::log_init;
 #[cfg(not(feature = "fips"))]
 use openssl::pkey::{Id, PKey};
@@ -32,19 +33,20 @@ use crate::tests::kms::cover_crypt::{
 use crate::{
     actions::kms::symmetric::keys::create_key::CreateKeyAction,
     config::COSMIAN_CLI_CONF_ENV,
-    error::{
-        CosmianError,
-        result::{CosmianResult, CosmianResultHelper},
-    },
+    error::{CosmianError, result::CosmianResult},
     tests::{
         PROG_NAME,
         kms::{
-            KMS_SUBCOMMAND,
-            elliptic_curve::create_key_pair::create_ec_key_pair,
-            rsa::create_key_pair::{RsaKeyPairOptions, create_rsa_key_pair},
-            symmetric::create_key::create_symmetric_key,
-            utils::recover_cmd_logs,
+            KMS_SUBCOMMAND, symmetric::create_key::create_symmetric_key, utils::recover_cmd_logs,
         },
+    },
+};
+#[cfg(not(feature = "fips"))]
+use crate::{
+    error::result::CosmianResultHelper,
+    tests::kms::{
+        elliptic_curve::create_key_pair::create_ec_key_pair,
+        rsa::create_key_pair::{RsaKeyPairOptions, create_rsa_key_pair},
     },
 };
 
@@ -199,6 +201,7 @@ pub(crate) async fn test_export_sym_allow_revoked() -> CosmianResult<()> {
     Ok(())
 }
 
+#[cfg(not(feature = "fips"))]
 #[tokio::test]
 pub(crate) async fn test_export_wrapped() -> CosmianResult<()> {
     log_init(option_env!("RUST_LOG"));
@@ -622,6 +625,7 @@ pub(crate) async fn test_sensitive_sym() -> CosmianResult<()> {
     Ok(())
 }
 
+#[cfg(not(feature = "fips"))]
 #[tokio::test]
 pub(crate) async fn test_sensitive_ec_key() -> CosmianResult<()> {
     // create a temp dir
@@ -661,6 +665,7 @@ pub(crate) async fn test_sensitive_ec_key() -> CosmianResult<()> {
     Ok(())
 }
 
+#[cfg(not(feature = "fips"))]
 #[tokio::test]
 pub(crate) async fn test_sensitive_rsa_key() -> CosmianResult<()> {
     // create a temp dir

--- a/crate/cli/src/tests/kms/shared/locate.rs
+++ b/crate/cli/src/tests/kms/shared/locate.rs
@@ -1,9 +1,12 @@
 use std::process::Command;
 
 use assert_cmd::prelude::*;
+#[cfg(not(feature = "fips"))]
 use cosmian_logger::log_init;
 use test_kms_server::start_default_test_kms_server_with_cert_auth;
 
+#[cfg(not(feature = "fips"))]
+use crate::tests::kms::elliptic_curve::create_key_pair::create_ec_key_pair;
 #[cfg(not(feature = "fips"))]
 use crate::tests::kms::{
     access::{grant_access, revoke_access},
@@ -20,7 +23,6 @@ use crate::{
         PROG_NAME,
         kms::{
             KMS_SUBCOMMAND,
-            elliptic_curve::create_key_pair::create_ec_key_pair,
             symmetric::create_key::create_symmetric_key,
             utils::{extract_uids::extract_locate_uids, recover_cmd_logs},
         },
@@ -215,6 +217,7 @@ pub(crate) async fn test_locate_cover_crypt() -> CosmianResult<()> {
     Ok(())
 }
 
+#[cfg(not(feature = "fips"))]
 #[tokio::test]
 pub(crate) async fn test_locate_elliptic_curve() -> CosmianResult<()> {
     log_init(option_env!("RUST_LOG"));

--- a/crate/cli/src/tests/kms/shared/revoke.rs
+++ b/crate/cli/src/tests/kms/shared/revoke.rs
@@ -11,6 +11,8 @@ use uuid::Uuid;
 use crate::tests::kms::cover_crypt::{
     master_key_pair::create_cc_master_key_pair, user_decryption_keys::create_user_decryption_key,
 };
+#[cfg(not(feature = "fips"))]
+use crate::tests::kms::elliptic_curve::create_key_pair::create_ec_key_pair;
 use crate::{
     actions::kms::symmetric::keys::create_key::CreateKeyAction,
     config::COSMIAN_CLI_CONF_ENV,
@@ -19,7 +21,6 @@ use crate::{
         PROG_NAME,
         kms::{
             KMS_SUBCOMMAND,
-            elliptic_curve::create_key_pair::create_ec_key_pair,
             shared::{ExportKeyParams, export::export_key},
             symmetric::create_key::create_symmetric_key,
             utils::recover_cmd_logs,
@@ -102,6 +103,7 @@ async fn test_revoke_symmetric_key() -> CosmianResult<()> {
     assert_revoked(&ctx.owner_client_conf_path, &key_id)
 }
 
+#[cfg(not(feature = "fips"))]
 #[tokio::test]
 async fn test_revoke_ec_key() -> CosmianResult<()> {
     // init the test server

--- a/crate/pkcs11/module/Cargo.toml
+++ b/crate/pkcs11/module/Cargo.toml
@@ -11,6 +11,9 @@ description = "Cross-platform PKCS#11 module written in rust, originally forked 
 [lib]
 doctest = false
 
+[features]
+fips = []
+
 [dependencies]
 bincode = "1.3.3"
 const-oid = "0.9.6"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,23 +11,3 @@ services:
       interval: 10s
       timeout: 5s
       retries: 5
-
-  findex-server:
-    depends_on:
-      - redis
-    container_name: findex-server
-    image: ghcr.io/cosmian/findex-server:0.3.0
-    ports:
-      - 16668:6668
-    environment:
-      RUST_LOG: cosmian_findex_server=info
-      FINDEX_SERVER_DATABASE_TYPE: redis
-      FINDEX_SERVER_DATABASE_URL: redis://redis:6379
-
-  kms:
-    container_name: kms
-    image: ghcr.io/cosmian/kms:develop
-    ports:
-      - 19998:9998
-    environment:
-      RUST_LOG: cosmian_kms_server=info


### PR DESCRIPTION
- also filter correctly FIPS-tests (several tests were only possible on non FIPS mode)